### PR TITLE
Better Rolling Deployments

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,6 @@
 source "https://supermarket.chef.io"
 
 metadata
+
+cookbook 'delivery-truck',
+  git: 'git@github.com:opscode-cookbooks/delivery-truck.git'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -39,12 +39,14 @@ module DeliveryGolang
       cookbooks
     end
 
-    # The Deployment Percentage specified in the `.delivery/config.json`
+    # The Deployment Percentage per Rolling Cookbook specified
+    # in the `.delivery/config.json`
     #
     # @param [Chef::Node] Chef Node object
+    # @param [String] Cookbook name
     # @return [String]
-    def delivery_golang_deploy_percentage(node)
-      node[CONFIG_ATTRIBUTE_KEY]['build_attributes']['deploy']['percentage']
+    def delivery_golang_deploy_rolling(node, cookbook)
+      node[CONFIG_ATTRIBUTE_KEY]['build_attributes']['deploy']['rolling'][cookbook]
     rescue
       100
     end
@@ -150,9 +152,9 @@ module DeliveryGolang
       DeliveryGolang::Helpers.delivery_golang_path(node)
     end
 
-    # Get the Golang Partial Path
-    def delivery_golang_deploy_percentage
-      DeliveryGolang::Helpers.delivery_golang_deploy_percentage (node)
+    # Get the deploy percentage per rolling cookbook
+    def delivery_golang_deploy_rolling(cookbook)
+      DeliveryGolang::Helpers.delivery_golang_deploy_rolling(node, cookbook)
     end
 
     # Get the Golang Project Full Path


### PR DESCRIPTION
As part of this project needs, we must trigger a CCR always
So we do the right deployment at the right time and order.

TODO: Order them as they are shown

``` .delivery/config.json
  "deploy": {
    "rolling": {
      "deploy-greentea": 20,
      "lb-greentea": 100,
      "audit": false,
    }
  }
```
